### PR TITLE
feat(BarChart): add datasets' labels to tooltip

### DIFF
--- a/src/assets/data.js
+++ b/src/assets/data.js
@@ -49,7 +49,7 @@ export const chartData = {
       y: '[[15, 19, 15, 13], [45, 40, 47, 41], [36, 32, 34, 44], [4, 9, 4, 2]]',
       name: '["Tout à fait satisfait", "Plutôt satisfait", "Plutôt pas satisfait", "Pas du tout satisfait"]',
       stacked: true,
-      selectedPalette: 'divergentDescending',
+      selectedPalette: 'divergentAscending',
       unitTooltip: '%',
     },
   },

--- a/src/components/BarChart.vue
+++ b/src/components/BarChart.vue
@@ -365,6 +365,7 @@ export default {
                     divValue.innerHTML += `
                     <div class="tooltip_value-content">
                       <span class="tooltip_dot" style="background-color:${color};"></span>
+                      ${tooltipModel.dataPoints.length > 1 ? `<p class="tooltip_place fr-mb-0">${this.datasets[datasetIndex].label}</p>` : ''}
                       <p class="tooltip_place fr-mb-0">${displayValue}</p>
                     </div>
                   `;

--- a/src/components/doc/Documentation.vue
+++ b/src/components/doc/Documentation.vue
@@ -175,6 +175,7 @@ const PALETTE_LABELS = {
   default: 'Palette par défaut',
   neutral: 'Palette unicolore',
   sequentialDescending: 'Palette séquentielle',
+  divergentAscending: 'Palette séquentielle divergente',
   divergentDescending: 'Palette séquentielle divergente',
 };
 

--- a/src/styles/Tooltip.scss
+++ b/src/styles/Tooltip.scss
@@ -53,6 +53,11 @@
       color: var(--text-default-grey);
       font-size: 0.9rem;
       font-weight: 400;
+
+      &:last-child {
+        margin-left: auto;
+        text-wrap: nowrap;
+      }
     }
 
     .tooltip_value {
@@ -63,7 +68,8 @@
 
       &-content {
         display: flex;
-        justify-content: space-between;
+        justify-content: flex-start;
+        column-gap: 0.55em;
         align-items: center;
         padding-top: 0.55rem;
         padding-left: 0.75rem;


### PR DESCRIPTION
Closes #29 
Supersedes #30 

**Description**

Cette Pull Request ajoute le nom des séries dans la tooltip lorsqu'il y a plusieurs séries dans le graphique de barres.
Le but est d'avoir une meilleure compréhension du graphique lors du survol du graphique avec le nom de série indiqué en plus de la couleur.

**Changements**

- Si le nombre de dataPoints est supérieur à 1, affichage du nom des datasets dans la tooltip
