### PR TITLE
feat(BarChart): add opt-in option to display total in tooltip's footer

### DIFF
--- a/src/assets/data.js
+++ b/src/assets/data.js
@@ -43,6 +43,7 @@ export const chartData = {
       horizontal: true,
       barSize: 20,
       unitTooltip: 'tonnes',
+      totalTooltip: true,
     },
     stacked: {
       x: '[["Ensemble des Français", "Agglomération parisienne", "Communauté urbaine de province", "Commune rurale"]]',

--- a/src/components/BarChart.vue
+++ b/src/components/BarChart.vue
@@ -14,6 +14,7 @@
             <div class="tooltip_body">
               <div class="tooltip_value" />
             </div>
+            <div v-if="totalTooltip" class="tooltip_footer fr-text--sm fr-mb-0"/>
           </div>
 
           <canvas :ref="chartId" />
@@ -134,6 +135,14 @@ export default {
     unitTooltip: {
       type: String,
       default: '',
+    },
+    totalTooltip: {
+      type: [Boolean, String],
+      default: false,
+    },
+    totalTooltipLabel: {
+      type: String,
+      default: 'Total : ',
     },
   },
   data() {
@@ -369,6 +378,14 @@ export default {
                     </div>
                   `;
                   });
+
+                  if (!!this.totalTooltip) {
+                    const divFooter = tooltipEl.querySelector('.tooltip_footer');
+                    const total = this.formatNumber(tooltipModel.dataPoints.reduce((current, dataPoint) => current + (this.horizontal ? dataPoint.parsed.x : dataPoint.parsed.y), 0));
+                    const displayTotal = `${total}${this.unitTooltip ? ' ' + this.unitTooltip : ''}`;
+
+                    divFooter.innerHTML = `${this.totalTooltipLabel}${displayTotal}`;
+                  }
                 }
 
                 // Position the tooltip

--- a/src/styles/Tooltip.scss
+++ b/src/styles/Tooltip.scss
@@ -12,7 +12,7 @@
   min-width: 7rem;
   max-width: 18rem;
 
-  &_header {
+  &_header, &_footer {
     width: 100%;
     font-size: 0.75rem;
     max-height: 3.5rem;


### PR DESCRIPTION
**Description**

Cette Pull Request introduit une nouvelle fonctionnalité dans les graphiques en barres : l'affichage d'une tooltip récapitulative qui présente la valeur totale, en complément des informations habituelles. Ce changement vise à améliorer la lisibilité et la compréhension du graphique en permettant aux utilisateurs de visualiser rapidement le total associé à chaque barre lors du survol, renforçant ainsi l'interprétation visuelle des données.

**Changements**

- Ajout d'une nouvelle option `totalTooltip` (défaut à `false`) pour choisir si on souhaite afficher ce total ou non.
- Ajout d'une nouvelle option `totalTooltipLabel` (défaut à `Total : `) pour contrôler l'affichage du total dans le footer.
- Ajout d'un footer au tooltip si `totalTooltip` est `true`able.