### PR TITLE
Reverse getDivergentAscending and getDivergentDescending

### DIFF
--- a/src/utils/colors.js
+++ b/src/utils/colors.js
@@ -184,18 +184,20 @@ export function getSequentialDescending() {
 export function getDivergentAscending() {
   const themeColors = getThemeColors();
   return chroma.scale([
-    themeColors['dsfr-chart-colors-11'],
-    themeColors['dsfr-chart-colors-13'],
-    themeColors['dsfr-chart-colors-15'],
+			themeColors['dsfr-chart-colors-15'],
+			themeColors['dsfr-chart-colors-13'],
+			themeColors['dsfr-chart-colors-11'],
+
   ]).colors(4);
 }
 
 export function getDivergentDescending() {
   const themeColors = getThemeColors();
   return chroma.scale([
-    themeColors['dsfr-chart-colors-15'],
-    themeColors['dsfr-chart-colors-13'],
-    themeColors['dsfr-chart-colors-11'],
+			themeColors['dsfr-chart-colors-11'],
+			themeColors['dsfr-chart-colors-13'],
+			themeColors['dsfr-chart-colors-15'],
+
   ]).colors(4);
 }
 


### PR DESCRIPTION
### Description

Les fonctions pour créer des palettes de couleurs ascendantes et descendantes étaient inversées. La palette ascendante allait du vert vers le rouge et la palette descendante du rouge vers le vert alors que c'est le contraire qui est attendu (voir plus de détails dans l'issue 39).


Fixes #39 

### Changement
Les couleurs des 2 fonctions ont été inversées