### PR TITLE
Add series names to tooltip for BarChart

### DIFF
--- a/src/components/BarChart.vue
+++ b/src/components/BarChart.vue
@@ -362,9 +362,13 @@ export default {
                     const value = this.formatNumber(this.datasets[datasetIndex].data[index]);
                     const displayValue = `${value}${this.unitTooltip ? ' ' + this.unitTooltip : ''}`;
 
+																				const seriesname = this.nameParse ?? []
+
                     divValue.innerHTML += `
                     <div class="tooltip_value-content">
                       <span class="tooltip_dot" style="background-color:${color};"></span>
+																						${seriesname.length > 1 ? `<p class="tooltip_place fr-mb-0">${seriesname[datasetIndex] ?? ""} : </p>` : ''}
+																			</span>
                       <p class="tooltip_place fr-mb-0">${displayValue}</p>
                     </div>
                   `;


### PR DESCRIPTION
### Description

Cette Pull Request ajoute le nom des séries dans la tooltip lorsqu'il y a plusieurs séries dans le graphique de barres.
Le but est d'avoir une meilleure compréhension du graphique lors du survol du graphique avec le nom de série indiqué en plus de la couleur.

Fixes #29 

### Changements

Création d'un tableau listant le nom des séries
Si le nombre de séries est supérieur à 1,affichage du nom des séries dans la tooltip