### PR TITLE
fix(storybook): use development files for storybook

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -2,8 +2,8 @@ import '../node_modules/@gouvfr/dsfr/dist/dsfr.module.min.js';
 import '../node_modules/@gouvfr/dsfr/dist/dsfr.main.min.css';
 import '../node_modules/@gouvfr/dsfr/dist/utility/utility.main.min.css';
 
-import '../dist/DSFRChart/DSFRChart.js';
-import '../dist/DSFRChart/DSFRChart.css';
+import '../src/charts/main.js';
+import '../src/styles/style.scss';
 
 import { html } from 'lit';
 


### PR DESCRIPTION
Proposition d'utilser directement les fichiers dans src pour le storybook afin d'éviter de devoir builder et de pouvoir développer directement les composants dans le storybook.