### PR TITLE
feat: ajout d'une valeur maximale pour le radar

### DIFF
--- a/src/assets/data.js
+++ b/src/assets/data.js
@@ -101,6 +101,13 @@ export const chartData = {
       name: '["1963", "2023"]',
       unitTooltip: '%',
     },
+    maxValue: {
+      x: '[["Logement, chauffage, éclairage", "Alimentation, boissons, tabac", "Autres biens et services", "Transports", "Communications, loisirs, culture", "Hôtels, cafés, restaurants", "Habillement et chaussures"], ["Logement, chauffage, éclairage", "Alimentation, boissons, tabac", "Autres biens et services", "Transports", "Communications, loisirs, culture", "Hôtels, cafés, restaurants", "Habillement et chaussures"]]',
+      y: '[[22.6, 28.9, 8.4, 10.7, 8.5, 5.3, 12.8], [31.3, 15.9, 13.4, 12.9, 10.5, 8.5, 3.0]]',
+      name: '["1963", "2023"]',
+      unitTooltip: '%',
+      maxValue: 30,
+    },
   },
   gaugeChart: {
     default: {

--- a/src/components/RadarChart.vue
+++ b/src/components/RadarChart.vue
@@ -81,6 +81,10 @@ export default {
       type: String,
       required: true,
     },
+	maxValue: {
+      type: Number,
+      required: false,
+	},
     name: {
       type: String,
       default: '',
@@ -271,6 +275,7 @@ export default {
               grid: {
                 color: '#6b6b6b',
               },
+              suggestedMax: this.maxValue
             },
           },
           plugins: {

--- a/src/stories/RadarChart.stories.js
+++ b/src/stories/RadarChart.stories.js
@@ -7,3 +7,7 @@ export default {
 export const Default = {
   args: chartData.radarChart.default,
 };
+
+export const MaxValue = {
+  args: chartData.radarChart.maxValue,
+};


### PR DESCRIPTION
Bonjour, voici une modification sur le radar :

## Description

Ajout d'une valeur maximale sur les graphes de type radar pour avoir une consistance de lecture même quand les valeurs changent (par exemple pour toujours afficher une taille 50 même si les valeurs changent).

Celà fait suite à un besoin de la DGSCGC pour un site annexe (je ne suis pas connecté avec mon compte professionnel).

## Ajouts

Un prop `maxValue` a été ajouté sur le radar pour permettre d'appliquer cette valeur maximale, et une visualisation a été ajoutée au Storybook.

A noter que si le graphe doit s'étendre plus que la valeur passé en entrée, elle est ignorée.